### PR TITLE
Changed sam_model_registry position

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ except ImportError:
 
 splash_update(None)
 
+import torch
 import tkinter
 from tkinter import filedialog
 import os
@@ -39,7 +40,7 @@ import PySimpleGUI as sg
 import cv2
 import numpy as np
 from PIL import Image, ImageTk
-from segment_anything import sam_model_registry, SamAutomaticMaskGenerator
+from segment_anything import sam_model_registry, SamAutomaticMaskGenerator, build_sam_vit_b
 
 root = tkinter.Tk()
 root.withdraw()     # use to hide tkinter window
@@ -52,6 +53,12 @@ reference_image = []
 out_full_res = []
 out_bw = []
 out_cropped = []
+prior_sam = {
+    'sam_checkpoint': '',
+    'model_type': '',
+    'device': ''
+}
+sam = build_sam_vit_b()
 
 # Default values
 sam_checkpoint = "sam_vit_h_4b8939.pth"
@@ -63,8 +70,6 @@ min_area = 100
 stability_thresh = 0.95
 predict_iou = 0.85
 
-sam = sam_model_registry[model_type](checkpoint=sam_checkpoint)
-sam.to(device=device)
 
 # General function for saving masks
 def save_mask_pic(mask_array):
@@ -85,6 +90,20 @@ def save_mask_pic(mask_array):
 
 # Segmentation function taking slider parameters and returning masks in various formats
 def segmentation(pps, area, st, iou):
+    global sam
+    if prior_sam['sam_checkpoint'] != sam_checkpoint or prior_sam['model_type'] != model_type or prior_sam['device'] != device:
+        for layer in sam.children():
+            if hasattr(layer, 'reset_parameters'):
+                layer.reset_parameters()
+        del sam
+        torch.cuda.empty_cache()
+        with torch.no_grad():
+            sam = sam_model_registry[model_type](checkpoint=sam_checkpoint)
+        sam.to(device=device)
+
+        prior_sam['sam_checkpoint'] = sam_checkpoint
+        prior_sam['model_type'] = model_type
+        prior_sam['device'] = device
 
     mask_generator = SamAutomaticMaskGenerator(
         model=sam,

--- a/main.py
+++ b/main.py
@@ -63,6 +63,8 @@ min_area = 100
 stability_thresh = 0.95
 predict_iou = 0.85
 
+sam = sam_model_registry[model_type](checkpoint=sam_checkpoint)
+sam.to(device=device)
 
 # General function for saving masks
 def save_mask_pic(mask_array):
@@ -83,8 +85,6 @@ def save_mask_pic(mask_array):
 
 # Segmentation function taking slider parameters and returning masks in various formats
 def segmentation(pps, area, st, iou):
-    sam = sam_model_registry[model_type](checkpoint=sam_checkpoint)
-    sam.to(device=device)
 
     mask_generator = SamAutomaticMaskGenerator(
         model=sam,


### PR DESCRIPTION
Registering the SAM each time the `segmentation` function is called caused multiple models enter into memory, and with a 2.5GB model, my RAM quickly filled up. Now the SAM is only registered once when the application starts.